### PR TITLE
Support the listed-info API update

### DIFF
--- a/src/get_data.jl
+++ b/src/get_data.jl
@@ -85,8 +85,20 @@ julia> getinfo(code="86970")
 ```
 
 """
-function getinfo(;code="")
-    listed_infos = get(ListedInfo; query=["code"=>code])["info"]
+function getinfo(;code="", date="")
+    date_str = date2str(date)
+
+    if isempty(code) && isempty(date_str)
+        query = []
+    elseif isempty(code)
+        query = ["date"=>date_str]
+    elseif isempty(date_str)
+        query = ["code"=>code]
+    else
+        query = ["date"=>date_str, "code"=>code]
+    end
+
+    listed_infos = get(ListedInfo; query=query)["info"]
     vcat(DataFrame.(listed_infos)...)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,14 +15,28 @@ end
 
 @testset "Listed issues information" begin
     code = "86970"  # JPX
-    listed_info = getinfo(code=code)
+    date = "20221111"
+    listed_info = getinfo(code=code, date=date)
 
+    expected_colnames = [
+        "Date", "Code", "CompanyName", "Sector17Code",
+        "Sector17CodeName", "Sector33Code", "Sector33CodeName",
+        "ScaleCategory", "MarketCode", "MarketCodeName",
+    ]
+
+    @test sort(names(listed_info)) == sort(expected_colnames)
+
+    @test listed_info[begin, :Date] == "20221111"
     @test listed_info[begin, :Code] == "86970"
-    @test listed_info[begin, :CompanyName] == "ＪＰＸ"
-    @test listed_info[begin, :CompanyNameEnglish] == "Japan Exchange Group,Inc."
-    @test listed_info[begin, :CompanyNameFull] == "（株）日本取引所グループ"
-    @test listed_info[begin, :MarketCode] == "A"
-    @test listed_info[begin, :SectorCode] == "7200"
+    @test listed_info[begin, :CompanyName] == "日本取引所グループ"
+    @test listed_info[begin, :Sector17Code] == "16"
+    @test listed_info[begin, :Sector17CodeName] == "金融（除く銀行）"
+    @test listed_info[begin, :Sector33Code] == "7200"
+    @test listed_info[begin, :Sector33CodeName] == "その他金融業"
+    @test listed_info[begin, :ScaleCategory] == "TOPIX Large70"
+    @test listed_info[begin, :MarketCode] == "111"
+    @test listed_info[begin, :MarketCodeName] == "プライム"
+
 end
 
 @testset "Listed sections" begin


### PR DESCRIPTION
Close #29.

- test: update tests for new listed info API
- feat: implement new listed info API wrapper
